### PR TITLE
issue9対応完了

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,12 +9,17 @@ class PostsController < ApplicationController
   end
 
   def new
+    @post = Post.new
   end
 
   def create
     @post = Post.new(content: params[:content])
-    @post.save
-    redirect_to("/posts/index")
+    if @post.save
+      flash[:notice] = "投稿が完了しました"
+      redirect_to("/posts/index")
+    else
+      render("posts/new")
+    end
   end
 
   def edit
@@ -24,16 +29,20 @@ class PostsController < ApplicationController
   def update
     @post = Post.find_by(id: params[:id])
     @post.content = params[:content]
-    @post.save
 
-    redirect_to("/posts/index")
+    if @post.save
+      flash[:notice] = "投稿を編集しました"
+      redirect_to("/posts/index")
+    else
+      render("posts/edit")
+    end
   end
 
   def destroy
     @post = Post.find_by(id: params[:id])
     @post.destroy
     @post.save
-
+    flash[:notice] = "投稿を削除しました"
     redirect_to("/posts/index")
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,3 @@
 class Post < ApplicationRecord
+    validates :content, {presence: true, length: {maximum: 140}}
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,9 @@
     <%= link_to("投稿一覧", "/posts/index") %>
     <%= link_to("新規投稿", "/posts/new") %>
   </header>
+    <% if flash[:notice] %>
+      <div><%= flash[:notice] %></div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,5 +1,8 @@
 <h2>投稿編集画面</h2>
 <%= form_tag("/posts/#{@post.id}/update") do %>
+    <% @post.errors.full_messages.each do |message| %>
+        <%= message %>
+    <% end %>
     <textarea name="content"><%= @post.content %></textarea>
     <input type="submit" value="投稿">
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,8 @@
 <h2>新規投稿画面</h2>
 <%= form_tag("/posts/create") do %>
-    <textarea name="content"></textarea>
+    <% @post.errors.full_messages.each do |message| %>
+        <%= message %>
+    <% end %>
+    <textarea name="content"><%= @post.content %></textarea>
     <input type="submit" value="投稿">
 <% end %>


### PR DESCRIPTION
## issue番号

#9 

## やったこと

- 140字以上で登録できないようにする。
- 空文字の投稿ができないようにする。
- 投稿完了時とエラー時にフラッシュメッセージを表示させる。

## やらなかったこと

- なし

## できるようになったこと（ユーザ目線）

- なし

## できなくなったこと（ユーザ目線）

- 140字以上の投稿
- 空文字の投稿

## 動作確認方法

- リンクをすべて踏む
- 新規投稿、編集、削除を行う

## 備考

- なし
