### PR TITLE
issue24対応完了

### DIFF
--- a/app/views/users/likes.html.erb
+++ b/app/views/users/likes.html.erb
@@ -5,8 +5,10 @@
   <li><%= link_to("投稿", "/users/#{@user.id}/show") %></li>
   <li><%= link_to("いいね!", "/users/#{@user.id}/likes") %></li>
 </ul>
-<%= link_to("編集", "/users/#{@user.id}/edit") %>
-<%= link_to("削除", "/users/#{@user.id}/destroy", {method: "post"}) %>
+<% if @current_user.id == @user.id %>
+  <%= link_to("編集", "/users/#{@user.id}/edit") %>
+  <%= link_to("削除", "/users/#{@user.id}/destroy", {method: "post"}) %>  
+<% end %>
 <p><%= "#{@user.name}のいいね一覧" %></p>
 <% @likes.each do |like| %>
   <% post = Post.find_by(id: like.post_id) %>  


### PR DESCRIPTION
## issue番号

#24 

## やったこと

- ログインユーザ以外のいいね！一覧画面で「編集」と「削除」をできないようにした。

## やらなかったこと

- なし

## できるようになったこと（ユーザ目線）

- なし

## できなくなったこと（ユーザ目線）

- いいね！一覧画面で自分以外のユーザ情報を「編集」、「削除」ができなくなった。

## 動作確認方法

- ログインユーザ以外のいいね！一覧ページに遷移して「編集」、「削除」ができないことを確認した。
- ログインユーザ以外のいいね！一覧ページにURLで直接遷移して「編集」、「削除」ができないことを確認した。

## 備考

- なし
