### PR TITLE
issue59対応完了

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,6 @@
       <header>
         <div id="header">    
           <ul>      
-              <li class="header-link"><%= link_to("ついったー", "/posts/index", class:"text") %></li>
               <li class="header-link"><%= link_to("新規投稿", "/posts/new", class:"text") %></li>
               <li class="header-link"><%= link_to("投稿一覧", "/posts/index", class:"text") %></li>
               <li class="header-link"><%= link_to("ユーザ一覧", "/users/index", class:"text") %></li>


### PR DESCRIPTION
## issue番号

closes #59 

## やったこと

- ヘッダーのついったー文字を削除

## やらなかったこと

- なし

## できるようになったこと（ユーザ目線）

- なし

## できなくなったこと（ユーザ目線）

- ヘッダーの「ついったー」から投稿一覧画面に遷移できなくなった。

## 動作確認方法

- ヘッダーについったーの文字が表示されていないことを確認した。

## 備考

- なし
