### PR TITLE
issue60対応完了

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -185,6 +185,11 @@ input {
   border: 0.3px solid;
 }
 
+.user-show-item {
+  text-decoration: none;
+  color: black;
+}
+
 .show-image-size {
   width: 125px;
   height: 125px;

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,9 @@
   <ul>
     <li>
       <% @user.posts.each do |post| %>
-        <div class="user-show-items"><%= post.content %></div>
+        <div class="user-show-items">
+          <%= link_to(post.content, "/posts/#{post.id}", class: "user-show-item") %>
+        </div>
       <% end %>
     </li>
   </ul>


### PR DESCRIPTION
## issue番号

closes #60 

## やったこと

- 投稿一覧のツイート内容をリンクにして、投稿詳細ページに遷移できるようにした。

## やらなかったこと

- なし

## できるようになったこと（ユーザ目線）

- 投稿一覧のツイート内容から投稿詳細に遷移できるようになった。

## できなくなったこと（ユーザ目線）

- なし

## 動作確認方法

- リンクを踏んだ際に正常に遷移できているか確認した。

## 備考

- なし
